### PR TITLE
Fix homepage in rubygems.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.1.5] - 2024-??-?? (Pastissos voladors de colors)
+
+- Fix homepage in rubygems.org
+
 ## [0.1.4] - 2024-01-30 (Peus grans com gegants)
 
 - Add users spam detector task

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-cdtb (0.1.4)
+    decidim-cdtb (0.1.5)
       decidim (>= 0.26.2)
       rails (>= 6)
       ruby-progressbar
@@ -775,4 +775,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.4.22
+   2.3.6

--- a/decidim-cdtb.gemspec
+++ b/decidim-cdtb.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary = "CodiTramuntana's Decidim Toolbelt (cdtb)."
   spec.description = "A gem to help managing Decidim applications."
-  spec.homepage = "http://github.com/CodiTramunana/cdtb"
+  spec.homepage = "https://github.com/CodiTramuntana/decidim-module-cdtb"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 2.7.5"
 

--- a/lib/decidim/cdtb/version.rb
+++ b/lib/decidim/cdtb/version.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Cdtb
-    VERSION = "0.1.4"
+    VERSION = "0.1.5"
     DECIDIM_MIN_VERSION = ">= 0.26.2"
   end
 end


### PR DESCRIPTION
The link to the module's homepage is broken in rubygems.org. In consequence, the changelog link  is also broken.

This PR fixes the homepage link in the gemspec file.