### PR TITLE
Add task to export the list of admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.4.2] - 2025-04-23 (minor -  Sant Jordi)
+
+- Add task to export the list of admins.
+
 ## [0.4.1] - 2025-02-10 (patch -  Afamada i enfadada)
 
 - Fix error in disabling/enabling emails on remove users task

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-cdtb (0.4.1)
+    decidim-cdtb (0.4.2)
       decidim (>= 0.27.0)
       rails (>= 6)
       ruby-progressbar

--- a/README.md
+++ b/README.md
@@ -221,11 +221,26 @@ bundle exec rake cdtb:participatory_spaces:add_content_blocks[['extra_data relat
 
 ```
 
+##### Usually executed when upgrading to Decidim 0.28
+
+To add extra_data and related_documents to content blocks in participatory spaces
+
+```
+bundle exec rake cdtb:participatory_spaces:add_content_blocks[extra_data]
+bundle exec rake cdtb:participatory_spaces:add_content_blocks[related_documents]
+```
+
+To move images to a new content block in participatory spaces
+
+```
+bundle exec rake cdtb:participatory_spaces:move_images_to_content_block
+```
+
 #### Move banner images to hero content block
 
 In previous versions of Decidim (0.27 and previous) banner images are in participatory space configuration. Now, this image is in a content block but for old spaces are in configuration yet.
 
-This task move the banner image to a hero content block.
+This task moves the banner image to a hero content block.
 
 Spaces supported:
 

--- a/lib/decidim/cdtb.rb
+++ b/lib/decidim/cdtb.rb
@@ -11,6 +11,8 @@ module Decidim
 
     class Error < StandardError; end
 
+    STRFTIME_FORMAT= "%d/%m/%Y %H:%M:%S"
+
     config_accessor :spam_words do
       %w[viagra sex game free crypto crack xxx luck girls vip download]
     end

--- a/lib/decidim/cdtb/version.rb
+++ b/lib/decidim/cdtb/version.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Cdtb
-    VERSION = "0.4.1"
+    VERSION = "0.4.2"
     DECIDIM_MIN_VERSION = ">= 0.27.0"
   end
 end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -19,5 +19,36 @@ namespace :cdtb do
       service = ::Decidim::Cdtb::Users::Remover.new(args.csv_path, args.reporter_user_email)
       service.execute!
     end
+
+    desc <<~EODESC
+      Exports the list of admins to a CSV file. If +org_id+ is set, filters by that organization.
+    EODESC
+    task :list_admins, %i[org_id] => [:environment] do |_taks, args|
+      organization_id= args.org_id
+
+      query= Decidim::User.includes(:organization).where(admin: true)
+      filename= "admins"
+
+      if organization_id.present?
+        query= query.where(organization_id: organization_id)
+        filename+= "-org#{organization_id}"
+      end
+
+      CSV.open("#{filename}.csv", "wb") do |csv|
+        csv << ["ID", "Organization ID", "Organization", "Name", "Email", "Created at", "Last sign in at"]
+
+        query.find_each do |admin|
+          csv << [
+            admin.id,
+            admin.organization.id,
+            admin.organization.name,
+            admin.name,
+            admin.email,
+            admin.created_at.strftime(Decidim::Cdtb::STRFTIME_FORMAT),
+            admin.last_sign_in_at&.strftime(Decidim::Cdtb::STRFTIME_FORMAT)
+          ]
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR will add a task to export the list of existing administrators to a CSV file.
It allows to filter by organization.