### PR TITLE
Update validate_migrations generator template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.5.2] - 2025-05-23 (patch - Sense por ni flotador)
+
+- Update validate_migrations generator template.
+
 ## [0.5.1] - 2025-04-14 (minor - Diferents però igual)
 
 - Add remove ActionLogs of users on remove users task.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GIT
 PATH
   remote: .
   specs:
-    decidim-cdtb (0.5.1)
+    decidim-cdtb (0.5.2)
       decidim (>= 0.28.0)
       rails (>= 6)
       ruby-progressbar

--- a/lib/decidim/cdtb/version.rb
+++ b/lib/decidim/cdtb/version.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Cdtb
-    VERSION = "0.5.1"
+    VERSION = "0.5.2"
     DECIDIM_MIN_VERSION = ">= 0.28.0"
   end
 end

--- a/lib/generators/cdtb/templates/validate_migrations.yml
+++ b/lib/generators/cdtb/templates/validate_migrations.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11
+        image: postgres:16
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready
@@ -36,7 +36,7 @@ jobs:
       SECRET_KEY_BASE: "secret_key_base"
 
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - uses: ruby/setup-ruby@master
@@ -44,7 +44,7 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
       - name: Recover Ruby dependency cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ./vendor/bundle
           key: ${{ runner.OS }}-app-rubydeps-${{ hashFiles('Gemfile.lock') }}
@@ -56,7 +56,7 @@ jobs:
         run: bundle config set --local path 'vendor/bundle'
 
       - name: Install Ruby deps
-        uses: nick-invision/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 10
           max_attempts: 3


### PR DESCRIPTION
Prepare a new patch version that updates the `validate_migrations` generator template.

It mainly updates the versions of used GH Actions as the previous became unavailable.