### PR TITLE
Use `main` as default git branch in CI generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Use `main` as default git branch in CI generators
+
 ## [0.5.3] - 2025-07-10 (patch - Aperitius explosius)
 
 - Add "cdtb" in RackAttack logs to ease finding them.

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ bundle exec rspec spec
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/CodiTramuntana/decidim-cdtb. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/CodiTramuntana/decidim-cdtb/blob/master/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/CodiTramuntana/decidim-cdtb. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/CodiTramuntana/decidim-cdtb/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 
@@ -308,4 +308,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Decidim::Cdtb project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/CodiTramuntana/decidim-cdtb/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Decidim::Cdtb project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/CodiTramuntana/decidim-cdtb/blob/main/CODE_OF_CONDUCT.md).

--- a/lib/generators/cdtb/github_actions/templates/ci_app.yml
+++ b/lib/generators/cdtb/github_actions/templates/ci_app.yml
@@ -3,7 +3,7 @@ name: "[CI] App"
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
       - "*-stable"
   pull_request:

--- a/lib/generators/cdtb/github_actions/templates/linters.yml
+++ b/lib/generators/cdtb/github_actions/templates/linters.yml
@@ -3,7 +3,7 @@ name: "[CI] Lint / Lint code"
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
       - "*-stable"
   pull_request:

--- a/lib/generators/cdtb/github_actions/templates/validate_migrations.yml
+++ b/lib/generators/cdtb/github_actions/templates/validate_migrations.yml
@@ -3,7 +3,7 @@ name: "[CI] Validate migrations"
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
       - "*-stable"
   pull_request:

--- a/lib/generators/cdtb/github_actions/templates/zeitwerk.yml
+++ b/lib/generators/cdtb/github_actions/templates/zeitwerk.yml
@@ -3,7 +3,7 @@ name: "[CI] Check Zeitwerk Class Loading"
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
       - "*-stable"
   pull_request:


### PR DESCRIPTION
Use `main` as default git branch in CI generators.